### PR TITLE
fix: fixes the issue with the github action checkout

### DIFF
--- a/.github/workflows/build-gochain.yml
+++ b/.github/workflows/build-gochain.yml
@@ -20,11 +20,11 @@ jobs:
         run: echo  "::set-output name=tag::$(curl -s https://api.github.com/repos/icon-project/goloop/releases/latest|grep '"name"'|cut -d '"' -f4)"
 
       - name: Clone goloop repository
-        uses: actions/checkout@v2
-        with:
-          repository: icon-project/goloop
-          ref: ${{ steps.repository.outputs.tag }}
-          path: goloop
+        run: git clone https://github.com/icon-project/goloop.git
+      
+      - name: Checkout the latest release version
+        run: git checkout ${{ steps.repository.outputs.tag }}
+        working-directory: goloop
 
       - name: Log in to docker hub registry
         uses: docker/login-action@v2


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of MIT license.**

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

For checking out the public repository of goloop, we are using the pre-defined action component called `actions/checkout`. However, they seems to have a bug where the GitHub token is being required even while cloning a  public repo. This happens even when running locally with act ([issue](https://github.com/nektos/act/issues/678#issuecomment-1321220127))

The suggested fix just does a normal git clone operation which seems to work just fine.


## Fixes: 
https://github.com/icon-community/drogon/issues/5


