### PR TITLE
fix: gochain build err on docker file

### DIFF
--- a/.github/workflows/build-gochain.yml
+++ b/.github/workflows/build-gochain.yml
@@ -38,6 +38,6 @@ jobs:
 
       - name: Push gochain-image to docker hub
         run: |
-          docker tag goloop/gochain:latest iconcommunity/gochain:${{ steps.repository.outputs.tag }}
-          docker push iconcommunity/gochain:${{ steps.repository.outputs.tag }}
+          docker tag goloop/gochain:latest iconcommunity/gochain:latest
+          docker push iconcommunity/gochain:latest
         working-directory: goloop

--- a/dockerfiles/Dockerfile.debian
+++ b/dockerfiles/Dockerfile.debian
@@ -23,9 +23,9 @@ ENV PATH="/usr/local/go/bin:/usr/local/go/goloop/bin/:${PATH}"
 WORKDIR /usr/local/go/
 
 # Install goloop
-RUN git clone https://github.com/icon-project/goloop.git \
-    && cd goloop \
-    && GOBUILD_TAGS= make goloop
+RUN git clone https://github.com/icon-project/goloop.git 
+RUN cd goloop 
+RUN GOBUILD_TAGS= make goloop
 
 WORKDIR /goloop
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 export const DROGON_IMAGE = 'iconcommunity/drogon:0.1.0';
 
-export const GOCHAIN_IMAGE = 'iconcommunity/gochain:v1.2.14';
+export const GOCHAIN_IMAGE = 'iconcommunity/gochain:latest';
 
 export const ICON_SANDBOX_DATA_REPO = 'icon-project/gochain-local';
 


### PR DESCRIPTION
**Changes**

The docker file for drogon was failing to build due to an error in building the gochain. Just by adding a multi-line RUN step it seems to have fixed the issue. This also have the benefit of better docker layer caching.

Also making the drogon use the latest gochain image (which has been updated in the GitHub action)