### PR TITLE
feat: adding the ability to build gochain-icon-image

### DIFF
--- a/.github/workflows/build-gochain.yml
+++ b/.github/workflows/build-gochain.yml
@@ -40,3 +40,13 @@ jobs:
           docker tag goloop/gochain:latest iconcommunity/gochain:latest
           docker push iconcommunity/gochain:latest
         working-directory: goloop
+      
+      - name: Build gochain-icon-image
+        run: make gochain-icon-image
+        working-directory: goloop
+
+      - name: Push gochain-icon-image to docker hub
+        run: |
+          docker tag goloop/gochain-icon:latest iconcommunity/gochain-icon:latest
+          docker push iconcommunity/gochain-icon:latest
+        working-directory: goloop


### PR DESCRIPTION
**Changes**

Adding the GitHub action to build the `gochain-icon` docker image since the project [gochain-local](https://github.com/icon-project/gochain-local) uses the gochain-icon image. 